### PR TITLE
Refactor/kakaologin

### DIFF
--- a/domain/src/main/kotlin/com/sooum/domain/repository/AuthRepository.kt
+++ b/domain/src/main/kotlin/com/sooum/domain/repository/AuthRepository.kt
@@ -54,6 +54,7 @@ interface AuthRepository {
         imageFile: File?
     ): Flow<ApiResult<PostProfileResult>>
 
+    /**
      * 버전을 체크 한다
      */
     suspend fun checkVersion(

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SignInFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SignInFragment.kt
@@ -52,7 +52,7 @@ class SignInFragment : AuthBaseFragment() {
                             requireActivity().finish()
                         }
                         showToast("로그인 성공")
-                        navigateActivity(MainActivity())
+                        (activity as AuthActivity).nextActivity()
                     }
 
                     is ApiResult.Fail -> {

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SocialLoginFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SocialLoginFragment.kt
@@ -35,9 +35,6 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class SocialLoginFragment : AuthBaseFragment() {
     private lateinit var binding: FragmentSocialLoginBinding
-    private val loadingAlertProvider by lazy {
-        LoadingAlertProvider(this)
-    }
 
     @Inject
     lateinit var  appManageDataStore: AppManageDataStore

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SocialLoginFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SocialLoginFragment.kt
@@ -145,7 +145,7 @@ class SocialLoginFragment : AuthBaseFragment() {
                             navigateTo(fragment)
                         } else {
                             showToast("카카오 로그인 성공")
-                            navigateActivity(MainActivity())
+                            (activity as AuthActivity).nextActivity()
                             requireActivity().finish()
                         }
                     }

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/EmailVerificationFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/EmailVerificationFragment.kt
@@ -17,9 +17,6 @@ import kotlinx.coroutines.flow.collectLatest
 @AndroidEntryPoint
 class EmailVerificationFragment : AuthBaseFragment() {
     private lateinit var binding : FragmentEmailVerificationBinding
-    private val loadingAlertProvider by lazy {
-        LoadingAlertProvider(this)
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/KakaoProfileSettingFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/KakaoProfileSettingFragment.kt
@@ -11,7 +11,8 @@ import androidx.lifecycle.lifecycleScope
 import com.sooum.domain.model.ApiResult
 import com.sooum.domain.model.ImageAddType
 import com.sooum.where_android.R
-import com.sooum.where_android.databinding.FragmentKakaoProfileSettingBinding
+import com.sooum.where_android.databinding.FragmentProfileSettingBinding
+import com.sooum.where_android.view.auth.AuthActivity
 import com.sooum.where_android.view.common.modal.ImagePickerDialogFragment
 import com.sooum.where_android.view.common.modal.LoadingAlertProvider
 import com.sooum.where_android.view.main.MainActivity
@@ -19,7 +20,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 
 class KakaoProfileSettingFragment : AuthBaseFragment() {
-    private lateinit var binding : FragmentKakaoProfileSettingBinding
+    private lateinit var binding : FragmentProfileSettingBinding
     private var selectedImageFile: File? = null
     private val userId: Int by lazy {
         requireArguments().getInt("userId")
@@ -29,7 +30,7 @@ class KakaoProfileSettingFragment : AuthBaseFragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentKakaoProfileSettingBinding.inflate(inflater, container, false)
+        binding = FragmentProfileSettingBinding.inflate(inflater, container, false)
 
         binding.imageCamera.setOnClickListener {
             val dialog = ImagePickerDialogFragment.getInstance(
@@ -55,7 +56,7 @@ class KakaoProfileSettingFragment : AuthBaseFragment() {
             dialog.show(parentFragmentManager, ImagePickerDialogFragment.TAG)
         }
 
-        binding.btnComplete.setOnClickListener {
+        binding.nextBtn.setOnClickListener {
             viewModel.putNickName(userId, binding.editNickname.text.toString())
             viewModel.updateProfile(userId, selectedImageFile)
         }
@@ -88,7 +89,7 @@ class KakaoProfileSettingFragment : AuthBaseFragment() {
                     is ApiResult.Success -> {
                         loadingAlertProvider.endLoading()
                         showToast("프로필 업데이트 성공.")
-                        navigateActivity(MainActivity())
+                        (activity as AuthActivity).nextActivity()
                     }
 
                     is ApiResult.Fail -> {

--- a/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/AuthViewModel.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/AuthViewModel.kt
@@ -12,6 +12,7 @@ import com.sooum.domain.usecase.auth.EmailVerifyUseCase
 import com.sooum.domain.usecase.auth.KakaoSignUpUseCase
 import com.sooum.domain.usecase.auth.LoginUseCase
 import com.sooum.domain.usecase.auth.NickNameUpdateUseCase
+import com.sooum.domain.usecase.auth.ProfileUpdateUseCase
 import com.sooum.domain.usecase.auth.RequestEmailAuthUseCase
 import com.sooum.domain.usecase.auth.SignUpUseCase
 import com.sooum.domain.usecase.auth.ValidatePasswordUseCase
@@ -30,7 +31,7 @@ class AuthViewModel @Inject constructor(
     private val signUpUseCase: SignUpUseCase,
     private val kakaoSignUpUseCase: KakaoSignUpUseCase,
     private val nickNameUpdateUseCase: NickNameUpdateUseCase,
-    private val profileUpdateUseCase: ProfileUpdateUseCase
+    private val profileUpdateUseCase: ProfileUpdateUseCase,
     private val getRequestEmailAuthUseCase: RequestEmailAuthUseCase,
     private val emailVerifyUseCase: EmailVerifyUseCase
 ) : ViewModel(){


### PR DESCRIPTION
- 카카오 로그인 시 토큰 저장 후 API 요청되도록 로그인 플로우 수정
- 불필요한 카카오 프로필 설정 화면 제거 및 기존 화면 재활용
- MainActivity로 이동 시 객체 생성 대신 nextActivity(MainActivity::class.java) 사용