### PR TITLE
Refactor/kakaologin

### DIFF
--- a/data/src/main/kotlin/com/sooum/data/di/NetworkModule.kt
+++ b/data/src/main/kotlin/com/sooum/data/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import com.sooum.data.network.NullOnEmptyConverterFactory
 import com.sooum.data.network.auth.AuthApi
 import com.sooum.data.network.comment.CommentApi
 import com.sooum.data.network.friend.FriendApi
+import com.sooum.data.network.kakao.KakaoApi
 import com.sooum.data.network.meet.MeetApi
 import com.sooum.data.network.place.PlaceApi
 import com.sooum.data.network.schedule.ScheduleApi
@@ -102,5 +103,13 @@ object NetworkModule {
         @WhereRetrofit retrofit: Retrofit
     ): AuthApi {
         return retrofit.create(AuthApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideKakaoApi(
+        @WhereRetrofit retrofit: Retrofit
+    ): KakaoApi {
+        return retrofit.create(KakaoApi::class.java)
     }
 }

--- a/data/src/main/kotlin/com/sooum/data/di/RepositoryModule.kt
+++ b/data/src/main/kotlin/com/sooum/data/di/RepositoryModule.kt
@@ -2,11 +2,13 @@ package com.sooum.data.di
 
 import com.sooum.data.repository.AuthRepositoryImpl
 import com.sooum.data.repository.FriendRepositoryImpl
+import com.sooum.data.repository.KakaoRepositoryImpl
 import com.sooum.data.repository.MeetDetailCommentRepositoryImpl
 import com.sooum.data.repository.MeetDetailPlaceRepositoryImpl
 import com.sooum.data.repository.MeetDetailRepositoryImpl
 import com.sooum.domain.repository.AuthRepository
 import com.sooum.domain.repository.FriendRepository
+import com.sooum.domain.repository.KakaoRepository
 import com.sooum.domain.repository.MeetDetailCommentRepository
 import com.sooum.domain.repository.MeetDetailPlaceRepository
 import com.sooum.domain.repository.MeetDetailRepository
@@ -50,4 +52,10 @@ abstract class RepositoryModule {
     abstract fun bindAuthRepository(
         impl: AuthRepositoryImpl
     ): AuthRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindKakaoRepository(
+        impl: KakaoRepositoryImpl
+    ): KakaoRepository
 }

--- a/data/src/main/kotlin/com/sooum/data/network/auth/AuthApi.kt
+++ b/data/src/main/kotlin/com/sooum/data/network/auth/AuthApi.kt
@@ -34,26 +34,6 @@ interface AuthApi {
         @Body data: LoginRequest
     ): Response<LoginResult>
 
-    @POST("api/user/kakao/login")
-    suspend fun kakaoLogin(
-        @Header("Authorization") authorization: String,
-        @Header("refreshToken") refreshToken: String
-    ): Response<KakaoSignUpResult>
-
-
-    @PUT("api/user/{userId}/nickname")
-    suspend fun putNickName(
-        @Path("userId") userId: Int,
-        @Body data: NameOnlyRequest
-    ) : Response<Unit>
-
-    @Multipart
-    @POST("api/user/{userId}/upload")
-    suspend fun postProfileImage(
-        @Path("userId") userId: Int,
-        @Part file: MultipartBody.Part?
-    ): Response<PostProfileResult>
-
     @GET("api/version")
     suspend fun versionCheck(
         @Query("type") type: String,

--- a/data/src/main/kotlin/com/sooum/data/network/kakao/KakaoApi.kt
+++ b/data/src/main/kotlin/com/sooum/data/network/kakao/KakaoApi.kt
@@ -1,0 +1,35 @@
+package com.sooum.data.network.kakao
+
+import com.sooum.data.network.auth.request.NameOnlyRequest
+import com.sooum.domain.model.KakaoSignUpResult
+import com.sooum.domain.model.PostProfileResult
+import okhttp3.MultipartBody
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Part
+import retrofit2.http.Path
+
+interface KakaoApi {
+    @POST("api/user/kakao/login")
+    suspend fun kakaoLogin(
+        @Header("Authorization") authorization: String,
+        @Header("refreshToken") refreshToken: String
+    ): Response<KakaoSignUpResult>
+
+    @PUT("api/user/{userId}/nickname")
+    suspend fun putNickName(
+        @Path("userId") userId: Int,
+        @Body data: NameOnlyRequest
+    ) : Response<Unit>
+
+    @Multipart
+    @POST("api/user/{userId}/upload")
+    suspend fun postProfileImage(
+        @Path("userId") userId: Int,
+        @Part file: MultipartBody.Part?
+    ): Response<PostProfileResult>
+}

--- a/data/src/main/kotlin/com/sooum/data/network/kakao/request/KakaoSignUpRequest.kt
+++ b/data/src/main/kotlin/com/sooum/data/network/kakao/request/KakaoSignUpRequest.kt
@@ -1,4 +1,4 @@
-package com.sooum.data.network.auth.request
+package com.sooum.data.network.kakao.request
 
 import kotlinx.serialization.Serializable
 

--- a/data/src/main/kotlin/com/sooum/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/sooum/data/repository/AuthRepositoryImpl.kt
@@ -59,48 +59,6 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun kakaoLogin(
-        accessToken: String,
-        refreshToken: String
-    ): Flow<ApiResult<KakaoSignUpResult>> {
-        return safeFlow {
-            authApi.kakaoLogin(
-                authorization = accessToken,
-                refreshToken = refreshToken
-            )
-        }
-    }
-
-
-    override suspend fun putNickName(userId: Int, nickName: String): Flow<ApiResult<Unit>> {
-        val request = NameOnlyRequest(nickName)
-        return safeFlow {
-            authApi.putNickName(
-                userId = userId,
-                request
-            )
-        }
-    }
-
-    override suspend fun postProfileImage(userId: Int, imageFile: File?) : Flow<ApiResult<PostProfileResult>> {
-        return if (imageFile != null){
-            safeFlow {
-                val requestFile = imageFile
-                    .asRequestBody("image/*".toMediaTypeOrNull())
-
-                val multipartBody = MultipartBody.Part.createFormData(
-                    name = "file",
-                    filename = imageFile.name,
-                    body = requestFile
-                )
-
-                authApi.postProfileImage(userId, multipartBody)
-            }
-        } else {
-            flowOf(ApiResult.Success(PostProfileResult("")))
-        }
-    }
-
     override suspend fun checkVersion(
         type: String,
         version: String

--- a/data/src/main/kotlin/com/sooum/data/repository/KakaoRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/sooum/data/repository/KakaoRepositoryImpl.kt
@@ -1,0 +1,64 @@
+package com.sooum.data.repository
+
+import com.sooum.data.datastore.AppManageDataStore
+import com.sooum.data.network.auth.request.NameOnlyRequest
+import com.sooum.data.network.kakao.KakaoApi
+import com.sooum.data.network.safeFlow
+import com.sooum.domain.model.ApiResult
+import com.sooum.domain.model.KakaoSignUpResult
+import com.sooum.domain.model.PostProfileResult
+import com.sooum.domain.repository.KakaoRepository
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+
+class KakaoRepositoryImpl @Inject constructor(
+    private val kakaoApi: KakaoApi,
+    private val appManageDataStore: AppManageDataStore
+) : KakaoRepository {
+
+    override suspend fun kakaoLogin(
+        accessToken: String,
+        refreshToken: String
+    ): Flow<ApiResult<KakaoSignUpResult>> {
+        return safeFlow {
+            kakaoApi.kakaoLogin(
+                authorization = accessToken,
+                refreshToken = refreshToken
+            )
+        }
+    }
+
+    override suspend fun putNickName(userId: Int, nickName: String): Flow<ApiResult<Unit>> {
+        val request = NameOnlyRequest(nickName)
+        return safeFlow {
+            kakaoApi.putNickName(
+                userId = userId,
+                request
+            )
+        }
+    }
+
+    override suspend fun postProfileImage(userId: Int, imageFile: File?) : Flow<ApiResult<PostProfileResult>> {
+        return if (imageFile != null){
+            safeFlow {
+                val requestFile = imageFile
+                    .asRequestBody("image/*".toMediaTypeOrNull())
+
+                val multipartBody = MultipartBody.Part.createFormData(
+                    name = "file",
+                    filename = imageFile.name,
+                    body = requestFile
+                )
+
+                kakaoApi.postProfileImage(userId, multipartBody)
+            }
+        } else {
+            flowOf(ApiResult.Success(PostProfileResult("")))
+        }
+    }
+}

--- a/domain/src/main/kotlin/com/sooum/domain/repository/AuthRepository.kt
+++ b/domain/src/main/kotlin/com/sooum/domain/repository/AuthRepository.kt
@@ -30,31 +30,6 @@ interface AuthRepository {
     ): Flow<ApiResult<LoginResult>>
 
     /**
-     * 카카오 로그인을 한다
-     */
-    suspend fun kakaoLogin(
-        accessToken: String,
-        refreshToken: String
-    ): Flow<ApiResult<KakaoSignUpResult>>
-
-    /**
-
-     * 닉네임을 변경한다
-     */
-    suspend fun putNickName(
-        userId: Int,
-        nickName: String
-    ): Flow<ApiResult<Unit>>
-
-    /**
-     * 프로필을 엡데이트 한다
-     */
-    suspend fun postProfileImage(
-        userId: Int,
-        imageFile: File?
-    ): Flow<ApiResult<PostProfileResult>>
-
-    /**
      * 버전을 체크 한다
      */
     suspend fun checkVersion(

--- a/domain/src/main/kotlin/com/sooum/domain/repository/KakaoRepository.kt
+++ b/domain/src/main/kotlin/com/sooum/domain/repository/KakaoRepository.kt
@@ -1,0 +1,34 @@
+package com.sooum.domain.repository
+
+import com.sooum.domain.model.ApiResult
+import com.sooum.domain.model.KakaoSignUpResult
+import com.sooum.domain.model.PostProfileResult
+import kotlinx.coroutines.flow.Flow
+import java.io.File
+
+interface KakaoRepository {
+
+    /**
+     * 카카오 로그인을 한다
+     */
+    suspend fun kakaoLogin(
+        accessToken: String,
+        refreshToken: String
+    ): Flow<ApiResult<KakaoSignUpResult>>
+
+    /**
+     * 닉네임을 변경한다
+     */
+    suspend fun putNickName(
+        userId: Int,
+        nickName: String
+    ): Flow<ApiResult<Unit>>
+
+    /**
+     * 프로필을 엡데이트 한다
+     */
+    suspend fun postProfileImage(
+        userId: Int,
+        imageFile: File?
+    ): Flow<ApiResult<PostProfileResult>>
+}

--- a/domain/src/main/kotlin/com/sooum/domain/usecase/kakao/KakaoSignUpUseCase.kt
+++ b/domain/src/main/kotlin/com/sooum/domain/usecase/kakao/KakaoSignUpUseCase.kt
@@ -1,18 +1,18 @@
-package com.sooum.domain.usecase.auth
+package com.sooum.domain.usecase.kakao
 
 import com.sooum.domain.model.ApiResult
 import com.sooum.domain.model.KakaoSignUpResult
-import com.sooum.domain.repository.AuthRepository
+import com.sooum.domain.repository.KakaoRepository
 import jakarta.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
 class KakaoSignUpUseCase @Inject constructor(
-    private val authRepository: AuthRepository
+    private val kakaoRepository: KakaoRepository
 ) {
     suspend operator fun invoke(
         accessToken: String,
         refreshToken: String
     ): Flow<ApiResult<KakaoSignUpResult>> {
-        return authRepository.kakaoLogin(accessToken, refreshToken)
+        return kakaoRepository.kakaoLogin(accessToken, refreshToken)
     }
 }

--- a/domain/src/main/kotlin/com/sooum/domain/usecase/kakao/NickNameUpdateUseCase.kt
+++ b/domain/src/main/kotlin/com/sooum/domain/usecase/kakao/NickNameUpdateUseCase.kt
@@ -1,14 +1,14 @@
-package com.sooum.domain.usecase.auth
+package com.sooum.domain.usecase.kakao
 
 import com.sooum.domain.model.ApiResult
-import com.sooum.domain.repository.AuthRepository
+import com.sooum.domain.repository.KakaoRepository
 import jakarta.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
 class NickNameUpdateUseCase @Inject constructor(
-    private val authRepository: AuthRepository
+    private val kakaoRepository: KakaoRepository
 ) {
     suspend operator fun invoke(userId: Int, nickName: String): Flow<ApiResult<Unit>>{
-        return authRepository.putNickName(userId, nickName)
+        return kakaoRepository.putNickName(userId, nickName)
     }
 }

--- a/domain/src/main/kotlin/com/sooum/domain/usecase/kakao/ProfileUpdateUseCase.kt
+++ b/domain/src/main/kotlin/com/sooum/domain/usecase/kakao/ProfileUpdateUseCase.kt
@@ -1,16 +1,16 @@
-package com.sooum.domain.usecase.auth
+package com.sooum.domain.usecase.kakao
 
 import com.sooum.domain.model.ApiResult
 import com.sooum.domain.model.PostProfileResult
-import com.sooum.domain.repository.AuthRepository
+import com.sooum.domain.repository.KakaoRepository
 import jakarta.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 class ProfileUpdateUseCase @Inject constructor(
-    private val authRepository: AuthRepository
+    private val kakaoRepository: KakaoRepository
 ) {
     suspend operator fun invoke(userId: Int, imageFile: File?): Flow<ApiResult<PostProfileResult>> {
-        return authRepository.postProfileImage(userId, imageFile)
+        return kakaoRepository.postProfileImage(userId, imageFile)
     }
 }

--- a/domain/src/main/kotlin/com/sooum/domain/usecase/kakao/ProfileUpdateUseCase.kt
+++ b/domain/src/main/kotlin/com/sooum/domain/usecase/kakao/ProfileUpdateUseCase.kt
@@ -1,16 +1,20 @@
 package com.sooum.domain.usecase.kakao
 
+import android.net.Uri
 import com.sooum.domain.model.ApiResult
 import com.sooum.domain.model.PostProfileResult
 import com.sooum.domain.repository.KakaoRepository
+import com.sooum.domain.util.UriConverter
 import jakarta.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 class ProfileUpdateUseCase @Inject constructor(
-    private val kakaoRepository: KakaoRepository
+    private val kakaoRepository: KakaoRepository,
+    private val uriConverter: UriConverter
 ) {
-    suspend operator fun invoke(userId: Int, imageFile: File?): Flow<ApiResult<PostProfileResult>> {
-        return kakaoRepository.postProfileImage(userId, imageFile)
+    suspend operator fun invoke(userId: Int, imageFile: Uri): Flow<ApiResult<PostProfileResult>> {
+        val file = uriConverter.saveContentUriToTempFile(imageFile)
+        return kakaoRepository.postProfileImage(userId, file)
     }
 }

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SignInFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SignInFragment.kt
@@ -1,7 +1,6 @@
 package com.sooum.where_android.view.auth
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,8 +8,6 @@ import androidx.lifecycle.lifecycleScope
 import com.sooum.domain.model.ApiResult
 import com.sooum.where_android.databinding.FragmentSignInBinding
 import com.sooum.where_android.view.auth.signup.AuthBaseFragment
-import com.sooum.where_android.view.common.modal.LoadingAlertProvider
-import com.sooum.where_android.view.main.MainActivity
 import kotlinx.coroutines.launch
 
 class SignInFragment : AuthBaseFragment() {
@@ -28,7 +25,7 @@ class SignInFragment : AuthBaseFragment() {
         super.onViewCreated(view, savedInstanceState)
         with(binding) {
             btnLogin.setOnClickListener {
-                viewModel.login(
+                authViewModel.login(
                     binding.editTextEmail.text.toString().trim(),
                     binding.editTextPassword.text.toString().trim()
                 )
@@ -42,7 +39,7 @@ class SignInFragment : AuthBaseFragment() {
 
     private fun observeSignInResult() {
         lifecycleScope.launch {
-            viewModel.loginState.collect { result ->
+            authViewModel.loginState.collect { result ->
                 when (result) {
                     is ApiResult.Loading -> {
                         loadingAlertProvider.startLoading()

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SocialLoginFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SocialLoginFragment.kt
@@ -107,9 +107,7 @@ class SocialLoginFragment : AuthBaseFragment() {
 
     private fun handleKakaoToken(accessToken: String, refreshToken: String) {
         lifecycleScope.launch {
-            appManageDataStore.saveKakaoAccessToken(accessToken)
-            appManageDataStore.saveKakaoRefreshToken(refreshToken)
-
+            kakaoViewModel.saveKakaoTokens(accessToken, refreshToken)
             kakaoViewModel.kakaoLogin(accessToken, refreshToken)
         }
     }

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SocialLoginFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/SocialLoginFragment.kt
@@ -1,7 +1,6 @@
 package com.sooum.where_android.view.auth
 
 import android.content.Context
-import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Paint
 import android.os.Build
@@ -10,12 +9,9 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.net.Uri
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
-import com.kakao.sdk.common.util.Utility
 import com.kakao.sdk.user.UserApiClient
 import com.sooum.data.datastore.AppManageDataStore
 import com.sooum.domain.model.ApiResult
@@ -23,13 +19,8 @@ import com.sooum.where_android.databinding.FragmentSocialLoginBinding
 import com.sooum.where_android.view.auth.signup.AgreementFragment
 import com.sooum.where_android.view.auth.signup.AuthBaseFragment
 import com.sooum.where_android.view.auth.signup.KakaoProfileSettingFragment
-import com.sooum.where_android.view.common.modal.LoadingAlertProvider
-import com.sooum.where_android.view.main.MainActivity
-import com.sooum.where_android.viewmodel.AuthViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import jakarta.inject.Inject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -69,7 +60,6 @@ class SocialLoginFragment : AuthBaseFragment() {
     private fun checkNotificationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val permission = android.Manifest.permission.POST_NOTIFICATIONS
-
             when {
                 ContextCompat.checkSelfPermission(
                     requireContext(),
@@ -120,14 +110,14 @@ class SocialLoginFragment : AuthBaseFragment() {
             appManageDataStore.saveKakaoAccessToken(accessToken)
             appManageDataStore.saveKakaoRefreshToken(refreshToken)
 
-            viewModel.kakaoLogin(accessToken, refreshToken)
+            kakaoViewModel.kakaoLogin(accessToken, refreshToken)
         }
     }
 
 
     private fun observeKakaoLoginResult() {
         lifecycleScope.launch {
-            viewModel.kakaoSignUpState.collect { result ->
+            kakaoViewModel.kakaoSignUpState.collect { result ->
                 when (result) {
                     is ApiResult.Loading -> {
                         loadingAlertProvider.startLoading()

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/AuthBaseFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/AuthBaseFragment.kt
@@ -9,9 +9,11 @@ import com.sooum.where_android.showSimpleToast
 import com.sooum.where_android.view.auth.AuthActivity
 import com.sooum.where_android.view.common.modal.LoadingAlertProvider
 import com.sooum.where_android.viewmodel.AuthViewModel
+import com.sooum.where_android.viewmodel.KakaoViewmodel
 
 abstract class AuthBaseFragment : Fragment() {
-    protected val viewModel: AuthViewModel by activityViewModels()
+    protected val authViewModel: AuthViewModel by activityViewModels()
+    protected val kakaoViewModel: KakaoViewmodel by activityViewModels()
 
     protected fun showToast(message: String) = showSimpleToast(message)
 

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/EmailVerificationFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/EmailVerificationFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
 import com.sooum.domain.model.ApiResult
 import com.sooum.where_android.databinding.FragmentEmailVerificationBinding
-import com.sooum.where_android.view.common.modal.LoadingAlertProvider
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import androidx.core.widget.doAfterTextChanged
@@ -31,7 +30,7 @@ class EmailVerificationFragment : AuthBaseFragment() {
 
         with(binding){
             nextBtn.setOnClickListener {
-               viewModel.verifyEmailCode(
+               authViewModel.verifyEmailCode(
                    binding.editTextEmail.text.toString().trim(),
                    binding.editTextCode.text.toString().trim()
                )
@@ -40,17 +39,17 @@ class EmailVerificationFragment : AuthBaseFragment() {
                 popBackStack()
             }
             btnEmail.setOnClickListener {
-                viewModel.getEmailAuth(binding.editTextEmail.text.toString().trim())
+                authViewModel.getEmailAuth(binding.editTextEmail.text.toString().trim())
             }
             editTextEmail.doAfterTextChanged { email ->
-                viewModel.onEmailVerifyInputChanged(
+                authViewModel.onEmailVerifyInputChanged(
                     email = email.toString(),
                     code = editTextCode.text.toString()
                 )
             }
 
             editTextCode.doAfterTextChanged { code ->
-                viewModel.onEmailVerifyInputChanged(
+                authViewModel.onEmailVerifyInputChanged(
                     email = editTextEmail.text.toString(),
                     code = code.toString()
                 )
@@ -64,7 +63,7 @@ class EmailVerificationFragment : AuthBaseFragment() {
 
     private fun observeEmailRequestResult() {
         lifecycleScope.launch {
-            viewModel.emailRequestState.collect { result ->
+            authViewModel.emailRequestState.collect { result ->
                 when (result) {
                     is ApiResult.Loading -> {
                         loadingAlertProvider.startLoading()
@@ -84,7 +83,7 @@ class EmailVerificationFragment : AuthBaseFragment() {
 
     private fun observeEmailVerificationResult() {
         lifecycleScope.launch {
-            viewModel.emailVerifyState.collect { result ->
+            authViewModel.emailVerifyState.collect { result ->
                 when (result) {
                     is ApiResult.Loading -> {
                         loadingAlertProvider.startLoading()
@@ -110,7 +109,7 @@ class EmailVerificationFragment : AuthBaseFragment() {
 
     private fun setUpBtnObserver(){
         lifecycleScope.launch {
-            viewModel.isEmailVerifyNextEnabled.collectLatest { isEnabled ->
+            authViewModel.isEmailVerifyNextEnabled.collectLatest { isEnabled ->
                 binding.nextBtn.isEnabled = isEnabled
                 binding.nextBtn.setBackgroundResource(
                     if (isEnabled) R.drawable.shape_rounded_button_main_color

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/KakaoProfileSettingFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/KakaoProfileSettingFragment.kt
@@ -2,7 +2,6 @@ package com.sooum.where_android.view.auth.signup
 
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,8 +13,6 @@ import com.sooum.where_android.R
 import com.sooum.where_android.databinding.FragmentProfileSettingBinding
 import com.sooum.where_android.view.auth.AuthActivity
 import com.sooum.where_android.view.common.modal.ImagePickerDialogFragment
-import com.sooum.where_android.view.common.modal.LoadingAlertProvider
-import com.sooum.where_android.view.main.MainActivity
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -57,8 +54,8 @@ class KakaoProfileSettingFragment : AuthBaseFragment() {
         }
 
         binding.nextBtn.setOnClickListener {
-            viewModel.putNickName(userId, binding.editNickname.text.toString())
-            viewModel.updateProfile(userId, selectedImageFile)
+            kakaoViewModel.putNickName(userId, binding.editNickname.text.toString())
+            kakaoViewModel.updateProfile(userId, selectedImageFile)
         }
 
         observePutNicknameResult()
@@ -81,7 +78,7 @@ class KakaoProfileSettingFragment : AuthBaseFragment() {
 
     private fun observePutNicknameResult() {
         lifecycleScope.launch {
-            viewModel.updateNicknameState.collect { result ->
+            kakaoViewModel.updateNicknameState.collect { result ->
                 when (result) {
                     is ApiResult.Loading -> {
                         loadingAlertProvider.startLoading()

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/KakaoProfileSettingFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/KakaoProfileSettingFragment.kt
@@ -18,7 +18,7 @@ import java.io.File
 
 class KakaoProfileSettingFragment : AuthBaseFragment() {
     private lateinit var binding : FragmentProfileSettingBinding
-    private var selectedImageFile: File? = null
+    private lateinit var selectedImageUri: Uri
     private val userId: Int by lazy {
         requireArguments().getInt("userId")
     }
@@ -42,7 +42,7 @@ class KakaoProfileSettingFragment : AuthBaseFragment() {
                                 // 앨범에서 선택한 이미지 적용
                                 binding.imageProfile.setImageURI(imageType.uri)
                                 binding.imageProfile.scaleType = ImageView.ScaleType.CENTER_CROP
-                                selectedImageFile = uriToFile(imageType.uri)
+                                selectedImageUri = imageType.uri
                             }
                             else -> {}
                         }
@@ -55,25 +55,12 @@ class KakaoProfileSettingFragment : AuthBaseFragment() {
 
         binding.nextBtn.setOnClickListener {
             kakaoViewModel.putNickName(userId, binding.editNickname.text.toString())
-            kakaoViewModel.updateProfile(userId, selectedImageFile)
+            kakaoViewModel.updateProfile(userId, selectedImageUri)
         }
 
         observePutNicknameResult()
 
         return binding.root
-    }
-
-    private fun uriToFile(uri: Uri): File? {
-        val context = requireContext()
-        val inputStream = context.contentResolver.openInputStream(uri) ?: return null
-        val file = File.createTempFile("temp_image", ".jpg", context.cacheDir)
-
-        inputStream.use { input ->
-            file.outputStream().use { output ->
-                input.copyTo(output)
-            }
-        }
-        return file
     }
 
     private fun observePutNicknameResult() {

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/PasswordFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/PasswordFragment.kt
@@ -30,8 +30,8 @@ class PasswordFragment : AuthBaseFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.nextBtn.setOnClickListener {
-            viewModel.setPassword(binding.editTextPassword.text.toString().trim())
-            viewModel.setEmail(binding.editTextEmail.text.toString().trim())
+            authViewModel.setPassword(binding.editTextPassword.text.toString().trim())
+            authViewModel.setEmail(binding.editTextEmail.text.toString().trim())
 
            navigateTo(ProfileSettingFragment())
         }
@@ -46,7 +46,7 @@ class PasswordFragment : AuthBaseFragment() {
 
     private fun setupObservers() {
         lifecycleScope.launch {
-            viewModel.isValidPassword.collectLatest { isValid ->
+            authViewModel.isValidPassword.collectLatest { isValid ->
                 if (binding.editTextPassword.text.isNullOrEmpty()) {
                     binding.textPasswordVerification.text = "영문+숫자+특수문자(!,~,@) 조합 8~32자"
                 } else if (isValid == false) {
@@ -59,7 +59,7 @@ class PasswordFragment : AuthBaseFragment() {
         }
 
         lifecycleScope.launch {
-            viewModel.isPasswordMatch.collectLatest { isMatch ->
+            authViewModel.isPasswordMatch.collectLatest { isMatch ->
                 if (binding.editTextPasswordRecheck.text.isNullOrEmpty()) {
                     binding.textPasswordRepeat.text = "비밀번호를 한 번 더 입력해주세요."
                 } else if (isMatch == false) {
@@ -72,7 +72,7 @@ class PasswordFragment : AuthBaseFragment() {
         }
 
         lifecycleScope.launch {
-            viewModel.isNextButtonEnabled.collectLatest { isEnabled ->
+            authViewModel.isNextButtonEnabled.collectLatest { isEnabled ->
                 binding.nextBtn.isEnabled = isEnabled
                 binding.nextBtn.setBackgroundResource(
                     if (isEnabled) R.drawable.shape_rounded_button_main_color
@@ -84,8 +84,8 @@ class PasswordFragment : AuthBaseFragment() {
 
 
     private fun setupListeners() {
-        binding.editTextPassword.addTextChangedListener { viewModel.onPasswordChanged(it.toString()) }
-        binding.editTextPasswordRecheck.addTextChangedListener { viewModel.onRePasswordChanged(it.toString()) }
-        binding.editTextEmail.addTextChangedListener { viewModel.onEmailChanged(it.toString()) }
+        binding.editTextPassword.addTextChangedListener { authViewModel.onPasswordChanged(it.toString()) }
+        binding.editTextPasswordRecheck.addTextChangedListener { authViewModel.onRePasswordChanged(it.toString()) }
+        binding.editTextEmail.addTextChangedListener { authViewModel.onEmailChanged(it.toString()) }
     }
 }

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/ProfileSettingFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/ProfileSettingFragment.kt
@@ -36,7 +36,7 @@ class ProfileSettingFragment : AuthBaseFragment() {
 
         with(binding){
             nextBtn.setOnClickListener{
-                viewModel.setName(binding.editNickname.text.toString().trim())
+                authViewModel.setName(binding.editNickname.text.toString().trim())
                navigateTo(SignUpCompleteFragment())
             }
 
@@ -56,7 +56,7 @@ class ProfileSettingFragment : AuthBaseFragment() {
                                 // 앨범에서 선택한 이미지 적용
                                 binding.imageProfile.setImageURI(imageType.uri)
                                 binding.imageProfile.scaleType = ImageView.ScaleType.CENTER_CROP
-                                viewModel.setProfileImage(imageType.uri.toString())
+                                authViewModel.setProfileImage(imageType.uri.toString())
                             }
                             else -> {}
                         }
@@ -70,7 +70,7 @@ class ProfileSettingFragment : AuthBaseFragment() {
 
     private fun setUpObservers(){
         lifecycleScope.launch {
-            viewModel.isNextButtonEnabled.collectLatest { isEnabled ->
+            authViewModel.isNextButtonEnabled.collectLatest { isEnabled ->
                 binding.nextBtn.isEnabled = isEnabled
                 binding.nextBtn.setBackgroundResource(
                     if (isEnabled) R.drawable.shape_rounded_button_main_color
@@ -81,6 +81,6 @@ class ProfileSettingFragment : AuthBaseFragment() {
     }
 
     private fun setupListeners() {
-        binding.editNickname.addTextChangedListener { viewModel.onNameChanged(it.toString()) }
+        binding.editNickname.addTextChangedListener { authViewModel.onNameChanged(it.toString()) }
     }
 }

--- a/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/SignUpCompleteFragment.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/view/auth/signup/SignUpCompleteFragment.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.lifecycleScope
 import com.sooum.domain.model.ApiResult
 import com.sooum.where_android.databinding.FragmentSignUpCompleteBinding
 import com.sooum.where_android.view.auth.AuthActivity
-import com.sooum.where_android.view.common.modal.LoadingAlertProvider
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -28,7 +27,7 @@ class SignUpCompleteFragment : AuthBaseFragment() {
         }
 
         binding.nextBtn.setOnClickListener {
-           viewModel.signUp()
+           authViewModel.signUp()
         }
 
         observeSignUpResult()
@@ -39,7 +38,7 @@ class SignUpCompleteFragment : AuthBaseFragment() {
 
     private fun observeSignUpResult() {
         lifecycleScope.launch {
-            viewModel.signUpState.collect { result ->
+            authViewModel.signUpState.collect { result ->
                 when (result) {
                     is ApiResult.Loading -> {
                         loadingAlertProvider.startLoading()

--- a/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/AuthViewModel.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/AuthViewModel.kt
@@ -1,18 +1,11 @@
 package com.sooum.where_android.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.sooum.domain.model.ApiResult
-import com.sooum.domain.model.EmailVerifyResult
-import com.sooum.domain.model.KakaoSignUpResult
 import com.sooum.domain.model.SignUpResult
 import com.sooum.domain.usecase.auth.EmailVerifyUseCase
-import com.sooum.domain.usecase.auth.KakaoSignUpUseCase
 import com.sooum.domain.usecase.auth.LoginUseCase
-import com.sooum.domain.usecase.auth.NickNameUpdateUseCase
-import com.sooum.domain.usecase.auth.ProfileUpdateUseCase
 import com.sooum.domain.usecase.auth.RequestEmailAuthUseCase
 import com.sooum.domain.usecase.auth.SignUpUseCase
 import com.sooum.domain.usecase.auth.ValidatePasswordUseCase
@@ -22,25 +15,18 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import java.io.File
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
     private val validatePasswordUseCase: ValidatePasswordUseCase,
     private val loginUseCase: LoginUseCase,
     private val signUpUseCase: SignUpUseCase,
-    private val kakaoSignUpUseCase: KakaoSignUpUseCase,
-    private val nickNameUpdateUseCase: NickNameUpdateUseCase,
-    private val profileUpdateUseCase: ProfileUpdateUseCase,
     private val getRequestEmailAuthUseCase: RequestEmailAuthUseCase,
     private val emailVerifyUseCase: EmailVerifyUseCase
 ) : ViewModel(){
 
     private val _loginState = MutableStateFlow<ApiResult<Any>>(ApiResult.SuccessEmpty)
     val loginState: StateFlow<ApiResult<Any>> = _loginState.asStateFlow()
-
-    private val _updateNicknameState = MutableStateFlow<ApiResult<Unit>>(ApiResult.SuccessEmpty)
-    val updateNicknameState: StateFlow<ApiResult<Unit>> = _updateNicknameState
   
     private val _emailRequestState = MutableStateFlow<ApiResult<Unit>>(ApiResult.SuccessEmpty)
     val emailRequestState: StateFlow<ApiResult<Unit>> = _emailRequestState.asStateFlow()
@@ -51,8 +37,6 @@ class AuthViewModel @Inject constructor(
     private val _signUpState = MutableStateFlow<ApiResult<SignUpResult>>(ApiResult.SuccessEmpty)
     val signUpState: StateFlow<ApiResult<SignUpResult>> = _signUpState
 
-    private val _kakaoSignUpState = MutableStateFlow<ApiResult<KakaoSignUpResult>>(ApiResult.SuccessEmpty)
-    val kakaoSignUpState: StateFlow<ApiResult<KakaoSignUpResult>> = _kakaoSignUpState
 
     private val _password = MutableStateFlow("")
     val password: StateFlow<String> = _password.asStateFlow()
@@ -106,19 +90,6 @@ class AuthViewModel @Inject constructor(
     }
 
     /**
-     * 카카오 회원가입 기능
-     */
-    fun kakaoLogin(authorization: String, refreshToken: String) {
-        viewModelScope.launch {
-           kakaoSignUpUseCase(
-               authorization ,refreshToken
-           ).collect{ result ->
-               _kakaoSignUpState.value = result
-           }
-        }
-    }
-
-    /**
      * 회원가입 기능
      */
     fun signUp(
@@ -131,32 +102,6 @@ class AuthViewModel @Inject constructor(
                 profileImage = _profileImage.value
             ).collect { result ->
                 _signUpState.value = result
-            }
-        }
-    }
-
-    /**
-     * 닉네임 수정 기능
-     */
-    fun putNickName(userId: Int, nickName: String){
-        viewModelScope.launch {
-            nickNameUpdateUseCase(
-                userId, nickName
-            ).collect{ result->
-                _updateNicknameState.value = result
-            }
-        }
-    }
-
-    /**
-     * 프로필 업데이트 기능
-     */
-    fun updateProfile(userId: Int,imageFile: File?){
-        viewModelScope.launch {
-            profileUpdateUseCase(
-                userId, imageFile
-            ).collect{ result ->
-              
             }
         }
     }

--- a/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/KakaoViewmodel.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/KakaoViewmodel.kt
@@ -3,6 +3,7 @@ package com.sooum.where_android.viewmodel
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sooum.data.datastore.AppManageDataStore
 import com.sooum.domain.model.ApiResult
 import com.sooum.domain.model.KakaoSignUpResult
 import com.sooum.domain.usecase.kakao.KakaoSignUpUseCase
@@ -20,6 +21,7 @@ class KakaoViewmodel @Inject constructor(
     private val kakaoSignUpUseCase: KakaoSignUpUseCase,
     private val nickNameUpdateUseCase: NickNameUpdateUseCase,
     private val profileUpdateUseCase: ProfileUpdateUseCase,
+    private val appManageDataStore: AppManageDataStore
 ) : ViewModel() {
 
     private val _kakaoSignUpState = MutableStateFlow<ApiResult<KakaoSignUpResult>>(ApiResult.SuccessEmpty)
@@ -64,6 +66,13 @@ class KakaoViewmodel @Inject constructor(
             ).collect{ result ->
 
             }
+        }
+    }
+
+    fun saveKakaoTokens(accessToken: String, refreshToken: String) {
+        viewModelScope.launch {
+            appManageDataStore.saveKakaoAccessToken(accessToken)
+            appManageDataStore.saveKakaoRefreshToken(refreshToken)
         }
     }
 }

--- a/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/KakaoViewmodel.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/KakaoViewmodel.kt
@@ -1,5 +1,6 @@
 package com.sooum.where_android.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sooum.domain.model.ApiResult
@@ -8,7 +9,7 @@ import com.sooum.domain.usecase.kakao.KakaoSignUpUseCase
 import com.sooum.domain.usecase.kakao.NickNameUpdateUseCase
 import com.sooum.domain.usecase.kakao.ProfileUpdateUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jakarta.inject.Inject
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -26,8 +27,6 @@ class KakaoViewmodel @Inject constructor(
 
     private val _updateNicknameState = MutableStateFlow<ApiResult<Unit>>(ApiResult.SuccessEmpty)
     val updateNicknameState: StateFlow<ApiResult<Unit>> = _updateNicknameState
-
-
 
     /**
      * 카카오 회원가입 기능
@@ -58,7 +57,7 @@ class KakaoViewmodel @Inject constructor(
     /**
      * 프로필 업데이트 기능
      */
-    fun updateProfile(userId: Int,imageFile: File?){
+    fun updateProfile(userId: Int,imageFile: Uri){
         viewModelScope.launch {
             profileUpdateUseCase(
                 userId, imageFile

--- a/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/KakaoViewmodel.kt
+++ b/presentation/src/main/kotlin/com/sooum/where_android/viewmodel/KakaoViewmodel.kt
@@ -1,0 +1,70 @@
+package com.sooum.where_android.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sooum.domain.model.ApiResult
+import com.sooum.domain.model.KakaoSignUpResult
+import com.sooum.domain.usecase.kakao.KakaoSignUpUseCase
+import com.sooum.domain.usecase.kakao.NickNameUpdateUseCase
+import com.sooum.domain.usecase.kakao.ProfileUpdateUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.io.File
+
+@HiltViewModel
+class KakaoViewmodel @Inject constructor(
+    private val kakaoSignUpUseCase: KakaoSignUpUseCase,
+    private val nickNameUpdateUseCase: NickNameUpdateUseCase,
+    private val profileUpdateUseCase: ProfileUpdateUseCase,
+) : ViewModel() {
+
+    private val _kakaoSignUpState = MutableStateFlow<ApiResult<KakaoSignUpResult>>(ApiResult.SuccessEmpty)
+    val kakaoSignUpState: StateFlow<ApiResult<KakaoSignUpResult>> = _kakaoSignUpState
+
+    private val _updateNicknameState = MutableStateFlow<ApiResult<Unit>>(ApiResult.SuccessEmpty)
+    val updateNicknameState: StateFlow<ApiResult<Unit>> = _updateNicknameState
+
+
+
+    /**
+     * 카카오 회원가입 기능
+     */
+    fun kakaoLogin(authorization: String, refreshToken: String) {
+        viewModelScope.launch {
+            kakaoSignUpUseCase(
+                authorization ,refreshToken
+            ).collect{ result ->
+                _kakaoSignUpState.value = result
+            }
+        }
+    }
+
+    /**
+     * 닉네임 수정 기능
+     */
+    fun putNickName(userId: Int, nickName: String){
+        viewModelScope.launch {
+            nickNameUpdateUseCase(
+                userId, nickName
+            ).collect{ result->
+                _updateNicknameState.value = result
+            }
+        }
+    }
+
+    /**
+     * 프로필 업데이트 기능
+     */
+    fun updateProfile(userId: Int,imageFile: File?){
+        viewModelScope.launch {
+            profileUpdateUseCase(
+                userId, imageFile
+            ).collect{ result ->
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
 - Fragment에서 직접 AppManageDataStore에 접근하던 로직을 제거
 - 프로필 등록 uriConverter 적용
 -  authViewmodel에서 카카오부분 kakaoViewmodel로 분리 